### PR TITLE
feat: add OpenAI integration for natural language task parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This workflow allows you to search, open, add, and complete tasks in [TickTick](
 
 - [Installation](#installation)
 - [Setup](#setup)
+  - [OpenAI Smart Parsing (Optional)](#openai-smart-parsing-optional)
 - [Usage](#usage)
   - [Lists](#lists)
     - [List Search](#list-search-tls-query)
@@ -48,6 +49,24 @@ Please note, this workflow is not an official TickTick product and is not affili
 5. Using Alfred, type in `tsetup1` and authorise the workflow, you'll be redirected to
    `http://localhost?code=xxxxx`. Please copy the code from the url.
 6. Using Alred, type in `tsetup2` followed by the code from the step 1 (e.g. `tsetup2 xxxxx`). You are now ready to use the workflow!
+
+### OpenAI Smart Parsing (Optional)
+
+Enable AI-powered natural language parsing for task creation:
+
+1. Get an API key from [OpenAI Platform](https://platform.openai.com/api-keys)
+2. Go to "Configure Workflow" in Alfred and paste your API key in the "OpenAI API Key" field
+
+With OpenAI enabled, you can create tasks using natural language:
+- `ttn buy milk tomorrow at 5pm` → Creates "Buy milk" with due date
+- `ttn run every wednesday at noon` → Creates "Run" with weekly recurrence
+- `ttn call mom urgent` → Creates "Call mom" with high priority
+
+The AI extracts:
+- **Task title** from conversational input
+- **Due date/time** from natural language ("tomorrow", "next monday", "in 2 hours")
+- **Repeat patterns** converted to RRULE format ("every day", "weekly on fridays")
+- **Priority** from keywords ("urgent", "important", "ASAP")
 
 ## Usage
 
@@ -94,12 +113,21 @@ Create a new task in TickTick with the given name.
 
 <img src="/docs/create_task.png" width="500"   alt="Create Task" />
 
-You can add an optional comma at the end and include a due date using natural language:
+**Basic mode** (without OpenAI): Add an optional comma and include a due date:
 
 - `ttn Do laundry`
 - `ttn Do the laundry, tomorrow at 5pm`
 - `ttn Do the laundry, next week`
 - `ttn Do the laundry, monday`
+
+**Smart mode** (with OpenAI): Just type naturally without commas:
+
+- `ttn buy groceries tomorrow evening` → "Buy groceries" due tomorrow at 6pm
+- `ttn meeting with John next monday at 10am` → "Meeting with John" due Monday 10:00
+- `ttn take vitamins every morning` → "Take vitamins" repeating daily at 9am
+- `ttn urgent fix the bug` → "Fix the bug" with high priority
+
+See [OpenAI Smart Parsing](#openai-smart-parsing-optional) for setup instructions.
 
 As mentioned in the [Current Limitations](#current-limitations) section, you can only add tasks to the Inbox list at the moment.
 
@@ -148,6 +176,7 @@ If you have any issues or feature requests, please open an [issue](https://githu
 - [TickTick API](https://developer.ticktick.com/api#/openapi) - The TickTick API used to build this workflow.
 - [ualfred](https://github.com/ischaojie/ualfred) & [Alfred Workflow](https://github.com/deanishe/alfred-workflow) - The python3 library fork and the Alfred workflow library used to build this workflow.
 - [parsedatetime](https://github.com/bear/parsedatetime/) - Used to parse natural language dates and times for creating tasks.
+- [OpenAI API](https://platform.openai.com/) - Powers the smart natural language task parsing feature.
 
 ## License
 

--- a/info.plist
+++ b/info.plist
@@ -863,11 +863,11 @@
 				<key>keyword</key>
 				<string>ttn</string>
 				<key>queuedelaycustom</key>
-				<integer>3</integer>
+				<integer>5</integer>
 				<key>queuedelayimmediatelyinitially</key>
 				<true/>
 				<key>queuedelaymode</key>
-				<integer>0</integer>
+				<integer>2</integer>
 				<key>queuemode</key>
 				<integer>1</integer>
 				<key>runningsubtext</key>
@@ -1133,6 +1133,27 @@
 			<string>textfield</string>
 			<key>variable</key>
 			<string>client_secret</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>sk-...</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>API key for OpenAI (optional - enables AI task parsing)</string>
+			<key>label</key>
+			<string>OpenAI API Key</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>openai_api_key</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/src/api/task.py
+++ b/src/api/task.py
@@ -44,6 +44,23 @@ async def create_task(token, task_name, due_date=None):
         if due_date.endswith('T00:00:00+0000'):
             data['isAllDay'] = True
 
-    # print(data)
+    return requests.post(url, headers=headers, json=data)
+
+
+async def create_task_full(token, task_data: dict):
+    """Create task with full data including repeatFlag.
+
+    Args:
+        token: TickTick access token
+        task_data: Dict with fields:
+            - title (required)
+            - dueDate (optional): ISO 8601 format
+            - isAllDay (optional): boolean
+            - repeatFlag (optional): RRULE format
+            - priority (optional): 0-5
+    """
+    headers = {"Authorization": "Bearer " + token}
+    url = TICKTICK_API_URL + '/task'
+    data = {k: v for k, v in task_data.items() if v is not None}
     return requests.post(url, headers=headers, json=data)
 

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM module for task parsing."""
+
+from .openai import parse_task_with_llm, TaskParseResult
+
+__all__ = ["parse_task_with_llm", "TaskParseResult"]

--- a/src/llm/openai.py
+++ b/src/llm/openai.py
@@ -1,0 +1,235 @@
+"""OpenAI client for task parsing."""
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+import requests
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+
+# JSON Schema for structured output
+TASK_RESPONSE_SCHEMA = {
+    "name": "task_parse_result",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Clear, actionable task title in imperative form"
+            },
+            "due_date": {
+                "type": ["string", "null"],
+                "description": "Due date in ISO 8601 format (yyyy-MM-ddTHH:mm:ss+0000) or null"
+            },
+            "repeat_flag": {
+                "type": ["string", "null"],
+                "description": "Repeat pattern in RRULE format or null"
+            },
+            "is_all_day": {
+                "type": "boolean",
+                "description": "True if no specific time was mentioned"
+            },
+            "priority": {
+                "type": "integer",
+                "description": "Priority: 0=normal, 1=low, 5=high"
+            }
+        },
+        "required": ["title", "due_date", "repeat_flag", "is_all_day", "priority"],
+        "additionalProperties": False
+    }
+}
+
+
+@dataclass
+class TaskParseResult:
+    """Parsed task from natural language input."""
+    title: str
+    due_date: Optional[str] = None
+    repeat_flag: Optional[str] = None
+    is_all_day: bool = False
+    priority: int = 0
+
+    def to_api_dict(self) -> dict:
+        """Convert to TickTick API format."""
+        data = {"title": self.title}
+        if self.due_date:
+            data["dueDate"] = self.due_date
+            data["isAllDay"] = self.is_all_day
+        if self.repeat_flag:
+            data["repeatFlag"] = self.repeat_flag
+        if self.priority:
+            data["priority"] = self.priority
+        return data
+
+
+def _get_example_dates(current_date: str, current_weekday: str) -> dict:
+    """Calculate real dates for prompt examples."""
+    base = datetime.strptime(current_date, "%Y-%m-%d")
+    tomorrow = (base + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    weekdays = {"Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3,
+                "Friday": 4, "Saturday": 5, "Sunday": 6}
+    current_wd = weekdays[current_weekday]
+
+    # Next Wednesday (2 = Wednesday)
+    days_until_wed = (2 - current_wd) % 7 or 7
+    next_wed = (base + timedelta(days=days_until_wed)).strftime("%Y-%m-%d")
+
+    # Next Monday (0 = Monday)
+    days_until_mon = (0 - current_wd) % 7 or 7
+    next_mon = (base + timedelta(days=days_until_mon)).strftime("%Y-%m-%d")
+
+    return {
+        "tomorrow": tomorrow,
+        "next_wednesday": next_wed,
+        "next_monday": next_mon
+    }
+
+
+def _build_system_prompt(current_date: str, current_weekday: str, timezone: str) -> str:
+    """Build system prompt for task parsing."""
+    dates = _get_example_dates(current_date, current_weekday)
+    return f"""You are a task parser for a todo app. Extract structured task data from natural language input.
+
+CURRENT CONTEXT:
+- Today's date: {current_date}
+- Today's weekday: {current_weekday}
+- Timezone: {timezone}
+
+RULES:
+1. Extract a clear, actionable task title (imperative form):
+   - "I need to order curtains" -> "Order curtains"
+   - "want to run every wednesday" -> "Run"
+   - "buy milk tomorrow" -> "Buy milk"
+   - "need to call mom" -> "Call mom"
+
+2. Parse date/time to ISO 8601 format (yyyy-MM-ddTHH:mm:ss+0000):
+   - "today" = current day
+   - "tomorrow" = next day
+   - "day after tomorrow" = current date + 2 days
+   - "at 7pm" / "by 7pm" = 19:00:00
+   - "at noon" / "at lunch" = 13:00:00
+   - "in the morning" = 09:00:00
+   - "in the evening" = 18:00:00
+   - "at night" = 23:00:00
+   - "in an hour" = current time + 1 hour
+   - "next week" = current date + 7 days
+   - "on monday" = next Monday
+   - If time not specified but date is -> is_all_day = true, time = 00:00:00
+   - If neither date nor time specified -> due_date = null
+
+3. Parse repeat patterns to RRULE format:
+   - "every day" / "daily" -> RRULE:FREQ=DAILY
+   - "every week" / "weekly" -> RRULE:FREQ=WEEKLY
+   - "every month" / "monthly" -> RRULE:FREQ=MONTHLY
+   - "every year" / "yearly" -> RRULE:FREQ=YEARLY
+   - "every wednesday" -> RRULE:FREQ=WEEKLY;BYDAY=WE
+   - "every monday" -> RRULE:FREQ=WEEKLY;BYDAY=MO
+   - "every weekend" -> RRULE:FREQ=WEEKLY;BYDAY=SA,SU
+   - "every weekday" / "on weekdays" -> RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+   - "every monday and wednesday" -> RRULE:FREQ=WEEKLY;BYDAY=MO,WE
+
+   Day codes: MO=Monday, TU=Tuesday, WE=Wednesday, TH=Thursday, FR=Friday, SA=Saturday, SU=Sunday
+
+   For recurring tasks, set due_date to the FIRST occurrence.
+
+4. Priority extraction:
+   - "urgent" / "important" / "ASAP" / "very important" -> priority = 5
+   - "not urgent" / "someday" / "low priority" -> priority = 1
+   - Default -> priority = 0
+
+EXAMPLES:
+- "order curtains tomorrow by 7pm" -> title="Order curtains", due_date="{dates['tomorrow']}T19:00:00+0000", is_all_day=false
+- "run every wednesday at noon" -> title="Run", due_date="{dates['next_wednesday']}T13:00:00+0000", repeat_flag="RRULE:FREQ=WEEKLY;BYDAY=WE"
+- "urgent call mom" -> title="Call mom", due_date=null, priority=5
+- "take vitamins every morning" -> title="Take vitamins", due_date="{dates['tomorrow']}T09:00:00+0000", repeat_flag="RRULE:FREQ=DAILY"
+- "buy milk" -> title="Buy milk", due_date=null, is_all_day=true
+- "meeting on monday at 10am" -> title="Meeting", due_date="{dates['next_monday']}T10:00:00+0000"
+
+IMPORTANT: Calculate actual dates based on today's date and weekday from CURRENT CONTEXT."""
+
+
+def parse_task_with_llm(
+    user_input: str,
+    api_key: str,
+    current_date: str,
+    current_weekday: str,
+    timezone: str = "+0000",
+    model: str = "gpt-4o-mini"
+) -> TaskParseResult:
+    """Parse natural language task input using OpenAI.
+
+    Args:
+        user_input: Natural language task description
+        api_key: OpenAI API key
+        current_date: Current date in ISO format (YYYY-MM-DD)
+        current_weekday: Current weekday in English (Monday, Tuesday, etc.)
+        timezone: Timezone offset (default: +0000)
+        model: OpenAI model to use (default: gpt-4o-mini)
+
+    Returns:
+        TaskParseResult with extracted fields
+    """
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": _build_system_prompt(current_date, current_weekday, timezone)
+            },
+            {
+                "role": "user",
+                "content": user_input
+            }
+        ],
+        "temperature": 0.1,
+        "max_tokens": 500,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": TASK_RESPONSE_SCHEMA
+        }
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    try:
+        response = requests.post(
+            OPENAI_API_URL,
+            json=payload,
+            headers=headers,
+            timeout=15
+        )
+
+        if response.status_code != 200:
+            return _fallback_parse(user_input)
+
+        result = response.json()
+        content = result.get("choices", [{}])[0].get("message", {}).get("content", "")
+        data = json.loads(content)
+
+        return TaskParseResult(
+            title=data.get("title", user_input),
+            due_date=data.get("due_date"),
+            repeat_flag=data.get("repeat_flag"),
+            is_all_day=data.get("is_all_day", False),
+            priority=data.get("priority", 0)
+        )
+
+    except Exception:
+        return _fallback_parse(user_input)
+
+
+def _fallback_parse(user_input: str) -> TaskParseResult:
+    """Simple fallback when LLM is unavailable."""
+    return TaskParseResult(
+        title=user_input,
+        due_date=None,
+        repeat_flag=None,
+        is_all_day=True,
+        priority=0
+    )

--- a/src/task-new-helper.py
+++ b/src/task-new-helper.py
@@ -1,33 +1,121 @@
 import sys
+import os
+import json
+from datetime import datetime
 from ualfred import Workflow
 from utils.parse import parse_new_task
+
 
 def main(wf):
     query = " ".join(wf.args)
 
-    if query.count(',') > 1:
-        wf.add_item(title="Too many commas", subtitle="Please only use one comma to separate your task name and due date", valid=True)
-        wf.send_feedback()
-        return
+    api_key = os.getenv("openai_api_key")
 
-    task_name, task_due_formatted, task_due_pretty = parse_new_task(query)
+    if api_key:
+        from llm.openai import parse_task_with_llm
 
-    title = "TickTick Task New: {}".format(task_name)
-    subtitle = "Create a new task with name '{}'".format(task_name)
-    arg = "{}|{}".format(task_name, task_due_formatted) if task_due_formatted else task_name
+        now = datetime.now()
+        current_date = now.strftime("%Y-%m-%d")
+        current_weekday = now.strftime("%A")  # Monday, Tuesday, etc.
 
-    if task_due_pretty:
-        subtitle += " and due {}".format(task_due_pretty)
+        result = parse_task_with_llm(
+            user_input=query,
+            api_key=api_key,
+            current_date=current_date,
+            current_weekday=current_weekday
+        )
+
+        subtitle_parts = []
+
+        if result.due_date:
+            due_display = _format_due_date(result.due_date)
+            subtitle_parts.append(f"Due: {due_display}")
+
+        if result.repeat_flag:
+            repeat_display = _format_repeat(result.repeat_flag)
+            subtitle_parts.append(f"Repeat: {repeat_display}")
+
+        if result.priority > 0:
+            priority_display = {1: "Low", 3: "Medium", 5: "High"}.get(result.priority, "")
+            if priority_display:
+                subtitle_parts.append(f"Priority: {priority_display}")
+
+        subtitle = " | ".join(subtitle_parts) if subtitle_parts else "No date"
+        arg = json.dumps(result.to_api_dict())
+
+        wf.add_item(
+            title=f"Create: {result.title}",
+            subtitle=subtitle,
+            arg=arg,
+            valid=True
+        )
     else:
-        subtitle += " (try using a comma and then add your time, e.g. tomorrow 10am)"
+        if query.count(',') > 1:
+            wf.add_item(
+                title="Too many commas",
+                subtitle="Please only use one comma to separate task name and due date",
+                valid=True
+            )
+            wf.send_feedback()
+            return
 
-    wf.add_item(title=title, subtitle=subtitle, arg=arg, valid=True)
+        task_name, task_due_formatted, task_due_pretty = parse_new_task(query)
+
+        title = "TickTick Task New: {}".format(task_name)
+        subtitle = "Create a new task with name '{}'".format(task_name)
+        arg = "{}|{}".format(task_name, task_due_formatted) if task_due_formatted else task_name
+
+        if task_due_pretty:
+            subtitle += " and due {}".format(task_due_pretty)
+
+        wf.add_item(title=title, subtitle=subtitle, arg=arg, valid=True)
+
     wf.send_feedback()
 
 
+def _format_due_date(iso_date: str) -> str:
+    """Format ISO date for display."""
+    try:
+        clean_date = iso_date.replace('+0000', '+00:00')
+        dt = datetime.fromisoformat(clean_date)
+        if dt.hour == 0 and dt.minute == 0:
+            return dt.strftime("%d/%m/%y")
+        return dt.strftime("%d/%m/%y %H:%M")
+    except Exception:
+        return iso_date
+
+
+def _format_repeat(rrule: str) -> str:
+    """Format RRULE for display."""
+    if not rrule:
+        return ""
+
+    rule = rrule.replace("RRULE:", "")
+    parts = dict(p.split("=") for p in rule.split(";") if "=" in p)
+
+    freq = parts.get("FREQ", "")
+    byday = parts.get("BYDAY", "")
+
+    freq_map = {
+        "DAILY": "Daily",
+        "WEEKLY": "Weekly",
+        "MONTHLY": "Monthly",
+        "YEARLY": "Yearly"
+    }
+
+    day_map = {
+        "MO": "Mon", "TU": "Tue", "WE": "Wed",
+        "TH": "Thu", "FR": "Fri", "SA": "Sat", "SU": "Sun"
+    }
+
+    result = freq_map.get(freq, freq)
+    if byday:
+        days = [day_map.get(d, d) for d in byday.split(",")]
+        result += f" ({', '.join(days)})"
+
+    return result
 
 
 if __name__ == u"__main__":
     wf = Workflow()
     sys.exit(wf.run(main))
-

--- a/src/task-new-post.py
+++ b/src/task-new-post.py
@@ -1,28 +1,37 @@
 import sys
+import json
 from ualfred import Workflow
-from api.task import create_task
+from api.task import create_task, create_task_full
 import asyncio
-from utils.sync import sync
+
 
 async def main(wf):
     query = " ".join(wf.args)
-    if "|" in query:
-        task_name, due_date = query.split("|")
-    else:
-        task_name, due_date = query, None
-
     token = wf.stored_data('access_token')
-    r = await create_task(token, task_name, due_date)
+
+    if not token:
+        print("Please run 'tsetup' to authenticate with TickTick first.")
+        return
+
+    try:
+        task_data = json.loads(query)
+        task_name = task_data.get('title', 'Task')
+        r = await create_task_full(token, task_data)
+    except json.JSONDecodeError:
+        if "|" in query:
+            task_name, due_date = query.split("|")
+        else:
+            task_name, due_date = query, None
+
+        r = await create_task(token, task_name, due_date)
+
     if r.status_code != 200:
-        print("Task could not be created. Please try again.")
+        print(f"Task could not be created: {r.text}")
     else:
-        # await sync(wf, should_fetch_lists=False, should_fetch_tasks=True)
-        print('{} task created.'.format(task_name))
+        print(f"'{task_name}' created.")
 
 
 if __name__ == u"__main__":
     wf = Workflow()
     asyncio.run(main(wf))
     sys.exit()
-
-


### PR DESCRIPTION
# Add OpenAI integration for natural language task parsing

  **Description**
  This PR adds OpenAI GPT integration to parse natural language task input into structured task data.
   When creating a new task with `ttn`, the workflow now:

  - Extracts actionable task title from conversational input ("I need to order curtains" → "Order
  curtains")
  - Parses dates and times from natural language ("tomorrow at 7pm", "at noon", "next week")
  - Detects repeat patterns and converts to RRULE format ("every Wednesday" →
  `RRULE:FREQ=WEEKLY;BYDAY=WE`)
  - Extracts priority from keywords ("urgent", "important")

  **Motivation and Context**
  The original workflow required manual date formatting with comma separator. This makes task
  creation more intuitive - users can simply type naturally and get properly structured tasks with
  dates and recurrence.

  OpenAI was chosen over YandexGPT for broader accessibility in the open-source community.

  **Checklist:**
  - [x] I have updated the documentation accordingly.
  - [x] I have tested the workflow and it works as expected.